### PR TITLE
Replaced hardcoded "python" excutable name with sys.executable

### DIFF
--- a/pyscreenshot/__init__.py
+++ b/pyscreenshot/__init__.py
@@ -32,7 +32,7 @@ def grab(bbox=None, childprocess=False, backend=None):
             params += ["backend='%s'" % (backend)]
         params = ','.join(params)
 
-        EasyProcess([sys.executable, #'python',
+        EasyProcess([sys.executable, 
                      '-c',
                      "import pyscreenshot; pyscreenshot.grab_to_file(%s)" % params,
                      ]).check()
@@ -60,7 +60,7 @@ def grab_to_file(filename, childprocess=False, backend=None):
             params += ["backend='%s'" % (backend)]
         params = ','.join(params)
 
-        EasyProcess([sys.executable, #'python',
+        EasyProcess([sys.executable, 
                      '-c',
                      "import pyscreenshot; pyscreenshot.grab_to_file(%s)" % params,
                      ]).check()


### PR DESCRIPTION
pyscreenshot wasn't working if pyscreenshot wasn't installed in the environment currently associated with the "python" command.

In my case, I was using it in my "python2.6" environment without using venv's.

By using sys.exectuable instead of hardcoding 'python', the EasyProcess calls will use the same python executable as the caller.

Here's the traceback I was getting:

> > > img = disp.waitgrab()
> > > \Traceback (most recent call last):
> > >   File "<stdin>", line 1, in <module>
> > >   File "/Library/Python/2.6/site-packages/pyvirtualdisplay/smartdisplay.py", line 68, in waitgrab
> > >     img = self.grab(autocrop=autocrop)
> > >   File "/Library/Python/2.6/site-packages/pyvirtualdisplay/smartdisplay.py", line 40, in grab
> > >     img = pyscreenshot.grab(childprocess=1, backend=self.pyscreenshot_backend)
> > >   File "/Library/Python/2.6/site-packages/pyscreenshot/**init**.py", line 36, in grab
> > >     "import pyscreenshot; pyscreenshot.grab_to_file(%s)" % params,
> > >   File "/Library/Python/2.6/site-packages/easyprocess/**init**.py", line 183, in check
> > >     raise EasyProcessError(self, 'check error, return code is not zero!')
> > > easyprocess.EasyProcessError: check error, return code is not zero! <EasyProcess cmd_param=['python', '-c', "import pyscreenshot; pyscreenshot.grab_to_file('/var/folders/H4/H4JS2F+iHyudZ-nYRNIiMk+++TI/-Tmp-/pyscreenshot_childprocess_OX4byu.png',childprocess=False)"] alias={alias} cmd=['python', '-c', "import pyscreenshot; pyscreenshot.grab_to_file('/var/folders/H4/H4JS2F+iHyudZ-nYRNIiMk+++TI/-Tmp-/pyscreenshot_childprocess_OX4byu.png',childprocess=False)"] ({scmd}) oserror=None returncode=1 stdout="" stderr="Traceback (most recent call last):
> > >   File "<string>", line 1, in <module>
> > > ImportError: No module named pyscreenshot" timeout=False>
