### PR TITLE
Fix the import for PIL backend.

### DIFF
--- a/pyscreenshot/plugins/pil.py
+++ b/pyscreenshot/plugins/pil.py
@@ -11,7 +11,7 @@ class PilWrapper(object):
     childprocess = False
 
     def __init__(self):
-        import ImageGrab  # windows only
+        from PIL import ImageGrab  # windows only
         self.ImageGrab = ImageGrab
 
     def grab(self, bbox=None):


### PR DESCRIPTION
I don't know why global import was used but it clearly doesn't work on Windows (tested with Pillow). If there isn't any reason to do otherwise, please accept this pull request and push a new version to PyPI.

Fixes #18, obviously.