### PR TITLE
Exclude fix import

### DIFF
--- a/pyscreenshot/plugins/mac_screencapture.py
+++ b/pyscreenshot/plugins/mac_screencapture.py
@@ -25,7 +25,7 @@ class ScreencaptureWrapper(object):
         return im
 
     def grab_to_file(self, filename, bbox=None):
-        command = 'screencapture -x'
+        command = 'screencapture -x '
         if filename.endswith('.jpeg'):
             command += ' -t jpg'
         elif filename.endswith('.tiff'):

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ VERSION = __version__
 extra = {}
 if sys.version_info >= (3,):
     extra['use_2to3'] = True
+    extra['use_2to3_exclude_fixers'] = ['lib2to3.fixes.fix_import']
 
 classifiers = [
     # Get more strings from


### PR DESCRIPTION
Allows Python3 use - see #17.  Note this requires all imports to be absolute  -- see https://wiki.python.org/moin/PortingPythonToPy3k#relative-imports.