### PR TITLE
Plugin for gnome-screenshots (supports Wayland)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,7 @@ Features:
      * wxPython_
      * Quartz (Mac)
      * screencapture (Mac)
+     * gnome-screenshot_
  * time: 0.1s - 1.0s
 
 Known problems:
@@ -141,6 +142,7 @@ Back-end performance::
   scrot               	0.93 sec	(   93 ms per call)
   imagemagick         	0.67 sec	(   67 ms per call)
   pyside              	1.3  sec	(  133 ms per call)
+  gnome-screenshot      18   sec        ( 1817 ms per call)
   #-#
 
 
@@ -154,6 +156,7 @@ Print versions::
   scrot                0.8
   imagemagick          6.7.7
   pyside               1.2.1
+  gnome-screenshot     3.26.0
   #-#
 
 
@@ -194,6 +197,7 @@ command line help
 .. _PyQt4: http://www.riverbankcomputing.co.uk/software/pyqt
 .. _PySide: http://www.pyside.org/
 .. _wxPython: http://www.wxpython.org/
+.. _gnome-screenshot: https://git.gnome.org/browse/gnome-screenshot/
 
 .. |Travis| image:: http://img.shields.io/travis/ponty/pyscreenshot.svg
    :target: https://travis-ci.org/ponty/pyscreenshot/

--- a/docs/hierarchy.rst
+++ b/docs/hierarchy.rst
@@ -33,6 +33,7 @@ Hierarchy
                 pyscreenshot -> ScrotWrapper;
                 pyscreenshot -> MacQuartzWrapper
                 pyscreenshot -> ScreencaptureWrapper
+                pyscreenshot -> GnomeScreenshotWrapper
             }
         }
         subgraph cluster_3 {
@@ -45,6 +46,7 @@ Hierarchy
             Quartz;
             Scrot;
             Imagemagick;
+            "gnome-screenshot";
         }
         subgraph cluster_4 {
             label = "GUI library";
@@ -62,6 +64,9 @@ Hierarchy
         PilWrapper -> PIL -> Windows;
         ImagemagickWrapper -> Imagemagick -> X11;
         ScrotWrapper -> Scrot -> X11;
+
+        GnomeScreenshotWrapper -> "gnome-screenshot" -> X11;
+        "gnome-screenshot" -> Wayland;
 
         GtkPixbufWrapper -> PyGTK -> "GTK+";
         "GTK+" -> MacOS;

--- a/pyscreenshot/plugins/__init__.py
+++ b/pyscreenshot/plugins/__init__.py
@@ -3,7 +3,8 @@
 import sys
 
 from pyscreenshot.plugins import wxscreen, gtkpixbuf, qtgrabwindow, scrot, \
-    imagemagick, mac_quartz, mac_screencapture, pil, pyside_grabwindow
+    imagemagick, mac_quartz, mac_screencapture, pil, pyside_grabwindow, \
+    gnome_screenshot
 
 
 if sys.platform == 'linux2':
@@ -14,6 +15,7 @@ if sys.platform == 'linux2':
         scrot.ScrotWrapper,
         imagemagick.ImagemagickWrapper,
         pyside_grabwindow.PySideGrabWindow,
+        gnome_screenshot.GnomeScreenshotWrapper,
     ]
 elif sys.platform == 'darwin':
     BACKENDS = [
@@ -47,6 +49,7 @@ else:
         mac_screencapture.ScreencaptureWrapper,
         mac_quartz.MacQuartzWrapper,
         pyside_grabwindow.PySideGrabWindow,
+        gnome_screenshot.GnomeScreenshotWrapper,
     ]
 
 

--- a/pyscreenshot/plugins/gnome_screenshot.py
+++ b/pyscreenshot/plugins/gnome_screenshot.py
@@ -1,0 +1,48 @@
+from easyprocess import EasyProcess
+from easyprocess import extract_version
+from PIL import Image
+import tempfile
+
+PROGRAM = 'gnome-screenshot'
+
+
+class GnomeScreenshotWrapper(object):
+    """
+    Plugin for ``pyscreenshot`` that uses ``gnome-screenshot``
+    https://git.gnome.org/browse/gnome-screenshot/
+
+    This plugin can take screenshot when system is running Wayland.
+    Info: https://bugs.freedesktop.org/show_bug.cgi?id=98672#c1
+    """
+    name = 'gnome-screenshot'
+    childprocess = True
+
+    def __init__(self):
+        EasyProcess([PROGRAM, '--version']).check_installed()
+
+    def grab(self, bbox=None):
+        f = tempfile.NamedTemporaryFile(
+            suffix='.png', prefix='pyscreenshot_gnome_screenshot_')
+        filename = f.name
+        self.grab_to_file(filename, bbox=bbox)
+        im = Image.open(filename)
+        return im
+
+    def grab_to_file(self, filename, bbox=None):
+        if bbox:
+            f = tempfile.NamedTemporaryFile(
+                suffix='.png', prefix='pyscreenshot_gnome_screenshot_tmp_')
+            tmp_filename = f.name
+        else:
+            tmp_filename = filename
+
+        command = 'gnome-screenshot -f ' + tmp_filename
+        EasyProcess(command).call()
+
+        if bbox:
+            im = Image.open(tmp_filename)
+            new_im = im.crop(bbox)
+            new_im.save(filename)
+
+    def backend_version(self):
+        return extract_version(EasyProcess([PROGRAM, '--version']).call().stdout.replace('-', ' '))

--- a/tests/test_gnome_screenshot.py
+++ b/tests/test_gnome_screenshot.py
@@ -1,0 +1,10 @@
+from ref import backend_ref
+from size import backend_size
+
+
+def test_size_gnome_screenshot():
+    backend_size('gnome-screenshot')
+
+
+def test_ref_gnome_screenshot():
+    backend_ref('gnome-screenshot')


### PR DESCRIPTION
I've created plugin that wraps gnome-screenshot tool. gnome-screenshot is the only tool that worked for me running GNOME Shell on Wayland. 
What is the issue and why to use gnome-screenshot?

Quote from https://bugs.freedesktop.org/show_bug.cgi?id=98672#c1 :
> By design, Wayland is a lot more secure than X11 and does not allow one application to capture the content of other applications' windows, meanignath a X11 based screenshot tool cannot work underWayland/Xwayland.
> 
> Both Weston and gnome-shell (Wayland compositors) have screencast and screenshot features built-in.

PROS: works with Wayland
CONS: gnome-screenshot takes more than 1s to take a screenshot.


