### PR TITLE
updated wx plugin to be up-to-date with the latest wx and Pillow

### DIFF
--- a/pyscreenshot/plugins/wxscreen.py
+++ b/pyscreenshot/plugins/wxscreen.py
@@ -21,15 +21,21 @@ class WxScreen(object):
             self.app = wx.App()
         screen = wx.ScreenDC()
         size = screen.GetSize()
-        bmp = wx.EmptyBitmap(size[0], size[1])
+        if hasattr(wx, "Bitmap"):
+            bmp = wx.Bitmap(size[0], size[1])
+        else:
+            bmp = wx.EmptyBitmap(size[0], size[1])
         mem = wx.MemoryDC(bmp)
         mem.Blit(0, 0, size[0], size[1], screen, 0, 0)
         del mem
-        myWxImage = wx.ImageFromBitmap(bmp)
+        if hasattr(bmp, "ConvertToImage"):
+            myWxImage = bmp.ConvertToImage()
+        else:
+            myWxImage = wx.ImageFromBitmap(bmp)
         im = Image.new('RGB', (myWxImage.GetWidth(), myWxImage.GetHeight()))
         if hasattr(Image, 'frombytes'):
             # for Pillow
-            im.frombytes(myWxImage.GetData())
+            im.frombytes(buffer(myWxImage.GetData()))
         else:
             # for PIL
             im.fromstring(myWxImage.GetData())

--- a/pyscreenshot/plugins/wxscreen.py
+++ b/pyscreenshot/plugins/wxscreen.py
@@ -21,7 +21,7 @@ class WxScreen(object):
             self.app = wx.App()
         screen = wx.ScreenDC()
         size = screen.GetSize()
-        if hasattr(wx, "Bitmap"):
+        if wx.__version__ >= '4':
             bmp = wx.Bitmap(size[0], size[1])
         else:
             bmp = wx.EmptyBitmap(size[0], size[1])


### PR DESCRIPTION
updates function names to get rid of 2 deprecation warnings:
`pyscreenshot/plugins/wxscreen.py:24: wxPyDeprecationWarning: Call to deprecated item EmptyBitmap. Use :class:'wx.Bitmap' instead`
`pyscreenshot/plugins/wxscreen.py:28: wxPyDeprecationWarning: Call to deprecated item ImageFromBitmap. Use bitmap.ConvertToImage instead.
  myWxImage = wx.ImageFromBitmap(bmp)`

wrap input to 1 function to fulfill the latest function argument of `frombytes` in `Pillow==5.2.0` to prevent error:
`TypeError: argument 1 must be string or read-only buffer, not bytearray`
