### PR TITLE
pygdk3 backend, using Gdk 3.0+, compatible with Python3 and pretty fa…

### DIFF
--- a/pyscreenshot/plugins/__init__.py
+++ b/pyscreenshot/plugins/__init__.py
@@ -3,13 +3,14 @@
 import sys
 
 from pyscreenshot.plugins import wxscreen, gtkpixbuf, qt4grabwindow, qt5grabwindow, \
-    scrot, imagemagick, mac_quartz, mac_screencapture, pil, pyside_grabwindow, gnome_screenshot
-
+    scrot, imagemagick, mac_quartz, mac_screencapture, pil, pyside_grabwindow, \
+    gnome_screenshot, gdk3pixbuf
 
 if sys.platform == 'linux2':
     BACKENDS = [
         wxscreen.WxScreen,
         gtkpixbuf.GtkPixbufWrapper,
+        gdk3pixbuf.Gdk3PixbufWrapper,
         qt4grabwindow.Qt4GrabWindow,
         qt5grabwindow.Qt5GrabWindow,
         scrot.ScrotWrapper,
@@ -23,6 +24,7 @@ elif sys.platform == 'darwin':
         mac_screencapture.ScreencaptureWrapper,
         wxscreen.WxScreen,
         gtkpixbuf.GtkPixbufWrapper,
+        gdk3pixbuf.Gdk3PixbufWrapper,
         qt4grabwindow.Qt4GrabWindow,
         qt5grabwindow.Qt5GrabWindow,
         scrot.ScrotWrapper,
@@ -34,6 +36,7 @@ elif sys.platform == 'win32':
         pil.PilWrapper,
         wxscreen.WxScreen,
         gtkpixbuf.GtkPixbufWrapper,
+        gdk3pixbuf.Gdk3PixbufWrapper,
         qt4grabwindow.Qt4GrabWindow,
         qt5grabwindow.Qt5GrabWindow,
         scrot.ScrotWrapper,
@@ -45,6 +48,7 @@ else:
         pil.PilWrapper,
         wxscreen.WxScreen,
         gtkpixbuf.GtkPixbufWrapper,
+        gdk3pixbuf.Gdk3PixbufWrapper,
         qt4grabwindow.Qt4GrabWindow,
         qt5grabwindow.Qt5GrabWindow,
         scrot.ScrotWrapper,

--- a/pyscreenshot/plugins/gdk3pixbuf.py
+++ b/pyscreenshot/plugins/gdk3pixbuf.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+"""Gdk3-based screenshotting.
+
+Adapted from https://stackoverflow.com/a/37768950/81636, but uses
+buffers directly instead of saving intermediate files (which is slow).
+"""
+from PIL import Image
+
+Gdk = None
+GdkPixbuf = None
+
+
+class Gdk3PixbufWrapper(object):
+    name = 'pygdk3'
+    childprocess = False
+
+    def __init__(self):
+        global Gdk, GdkPixbuf
+        import gi
+        gi.require_version('Gdk', '3.0')
+        from gi.repository import Gdk as _Gdk
+        from gi.repository import GdkPixbuf as _GdkPixbuf
+        Gdk, GdkPixbuf = _Gdk, _GdkPixbuf
+
+    def grab(self, bbox=None):
+        """Grabs an image directly to a buffer.
+
+        :param bbox: Optional tuple or list containing (x1, y1, x2, y2) coordinates
+            of sub-region to capture.
+        :return: PIL RGB image
+        :raises: ValueError, if image data does not have 3 bytes per pixel.
+        :rtype: Image
+        """
+        w = Gdk.get_default_root_window()
+        if bbox is not None:
+            g = [bbox[0], bbox[1], bbox[2] - bbox[0], bbox[3] - bbox[1]]
+        else:
+            g = w.get_geometry()
+        pb = Gdk.pixbuf_get_from_window(w, *g)
+        pixel_bytes = pb.read_pixel_bytes().get_data()  # type: bytes
+        bytes_per_pixel = len(pixel_bytes) // (g[2] * g[3])
+        if bytes_per_pixel != 3:
+            raise ValueError(
+                "Got {} bytes per pixel, expected 3.".format(bytes_per_pixel))
+        return Image.frombytes('RGB', (g.width, g.height), pixel_bytes, 'raw')
+
+    def grab_to_file(self, filename, bbox=None):
+        self.grab(bbox=bbox).save(filename)
+
+    def backend_version(self):
+        import gi
+        return '.'.join(map(str, gi.version_info))

--- a/pyscreenshot/plugins/gtkpixbuf.py
+++ b/pyscreenshot/plugins/gtkpixbuf.py
@@ -9,6 +9,11 @@ class GtkPixbufWrapper(object):
     def __init__(self):
         import gtk
         self.gtk = gtk
+        try:
+            gtk.gdk.Pixbuf
+            gtk.gdk.COLORSPACE_RGB
+        except AttributeError:
+            raise ImportError("Incompatible with Python3 / GDK3. Use gdk3pixbuf.")
 
     def grab(self, bbox=None):
         f = tempfile.NamedTemporaryFile(

--- a/tests/test_pygdk3.py
+++ b/tests/test_pygdk3.py
@@ -1,0 +1,10 @@
+from ref import backend_ref
+from size import backend_size
+
+
+def test_size_pygdk3():
+    backend_size('pygdk3')
+
+
+def test_ref_pygdk3():
+    backend_ref('pygdk3')


### PR DESCRIPTION
…st (~70ms for 4K screenshot)

Fixes / avoids https://github.com/ponty/pyscreenshot/issues/43

**N.B. you must use childprocess=False to get good performance!!** Unfortunately default Python inter-thread communication/forking/etc. is painfully slow. Compare:

```
In [5]: %time pyscreenshot.grab(backend='pygdk3')
CPU times: user 6.38 ms, sys: 0 ns, total: 6.38 ms
Wall time: 397 ms
Out[5]: <PIL.PngImagePlugin.PngImageFile image mode=RGB size=3840x2160 at 0x7F9721DA4908>

In [7]: %time pyscreenshot.grab(backend='pygdk3', childprocess=False)
CPU times: user 59.1 ms, sys: 27.9 ms, total: 87 ms
Wall time: 102 ms
Out[7]: <PIL.Image.Image image mode=RGB size=3840x2160 at 0x7F970E57FF28>

In [8]: %time pyscreenshot.grab(backend='pygdk3', childprocess=False)
CPU times: user 36.7 ms, sys: 12.1 ms, total: 48.8 ms
Wall time: 67.9 ms
Out[8]: <PIL.Image.Image image mode=RGB size=3840x2160 at 0x7F970E5841D0>

In [9]: %time pyscreenshot.grab(backend='pygdk3', childprocess=False)
CPU times: user 26.9 ms, sys: 19.4 ms, total: 46.2 ms
Wall time: 65.3 ms
Out[9]: <PIL.Image.Image image mode=RGB size=3840x2160 at 0x7F970E584550>
```

Backend speedtest (which does *not* use `childprocess=False`) results:

```
n=10                                                                                             
------------------------------------------------------                     
pygdk3                  3.8  sec        (  383 ms per call)
pyqt5                   7.4  sec        (  741 ms per call)
imagemagick             11   sec        ( 1062 ms per call)
gnome-screenshot        8.8  sec        (  883 ms per call)
```

but with `childprocess=False` it is an order of magnitude faster than other backends ^_^. Sorry I don't have scrot/pyside/pyqt/wx/pil backends installed to compare.