### PR TITLE
Remove broken Landscape badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -183,7 +183,5 @@ On Wayland only the `gnome-screenshot` back-end works::
    :target: https://pypi.python.org/pypi/pyscreenshot/
 .. |License| image:: https://img.shields.io/pypi/l/pyscreenshot.svg
    :target: https://pypi.python.org/pypi/pyscreenshot/
-.. |Code Health| image:: https://landscape.io/github/ponty/pyscreenshot/master/landscape.svg?style=flat
-   :target: https://landscape.io/github/ponty/pyscreenshot/master
 .. |Documentation| image:: https://readthedocs.org/projects/pyscreenshot/badge/?version=latest
    :target: http://pyscreenshot.readthedocs.org


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1324225/58689899-f3c7d600-8390-11e9-8ad7-4427d3f1e764.png)

The badge is broken and it looks like the service is dead or misconfigured; it's not analysed the code since 2018: https://landscape.io/github/ponty/pyscreenshot/