### PR TITLE
fix bug for scrot v1.1.1 not defaulting to overwrite tempfile.

### DIFF
--- a/pyscreenshot/plugins/scrot.py
+++ b/pyscreenshot/plugins/scrot.py
@@ -28,7 +28,7 @@ class ScrotWrapper(object):
         return im
 
     def _grab_to_file(self, filename):
-        EasyProcess([PROGRAM, '--silent', filename]).call()
+        EasyProcess([PROGRAM, '--silent', "--overwrite", filename]).call()
 
     def backend_version(self):
         return extract_version(


### PR DESCRIPTION
Patch to fix issue #67 should still work with scrot 0.8 and does work with v1.1.1