### PR TITLE
Add pillow as dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ classifiers = [
 install_requires = [
     "EasyProcess",
     "entrypoint2",
+    "pillow",
     "mss ; python_version > '3.4'",
     "jeepney ; python_version > '3.4' and platform_system == 'Linux'",
 ]

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ classifiers = [
 install_requires = [
     "EasyProcess",
     "entrypoint2",
-    "pillow",
+    "Pillow",
     "mss ; python_version > '3.4'",
     "jeepney ; python_version > '3.4' and platform_system == 'Linux'",
 ]


### PR DESCRIPTION
It's being imported in `pyscreenshot/imcodec.py`

noticed this when reviewing this package for nixpkgs https://github.com/NixOS/nixpkgs/pull/99244