### PR TITLE
Force latest `0.2.4` version for entrypoint2 dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 EasyProcess
-entrypoint2
+entrypoint2>=0.2.4
 mss ; python_version > '3.4'
 jeepney ; python_version > '3.4' and platform_system == 'Linux'


### PR DESCRIPTION
Hello @ponty, Thank you for resolving `argparse` dependency problem in entrypoint2. But unfortunately pip is still installing old entrypoint2 version on all my systems with pyscreenshot. This fix will resolve it,

Resolves redundant "argparse" requirement still getting automatically installed. Related: https://github.com/ponty/entrypoint2/issues/9