### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ import pyscreenshot as ImageGrab
 with Display(size=(100, 60)) as disp:  # start Xvfb display
     # display is available
     with EasyProcess(["xmessage", "hello"]):  # start xmessage
-        sleep(1)  # wait for diplaying window
+        sleep(1)  # wait for displaying window
         img = ImageGrab.grab()
 img.save("xmessage.png")
 

--- a/pyscreenshot/examples/virtdisp.py
+++ b/pyscreenshot/examples/virtdisp.py
@@ -9,6 +9,6 @@ import pyscreenshot as ImageGrab
 with Display(size=(100, 60)) as disp:  # start Xvfb display
     # display is available
     with EasyProcess(["xmessage", "hello"]):  # start xmessage
-        sleep(1)  # wait for diplaying window
+        sleep(1)  # wait for displaying window
         img = ImageGrab.grab()
 img.save("xmessage.png")

--- a/pyscreenshot/plugins/mac_screencapture.py
+++ b/pyscreenshot/plugins/mac_screencapture.py
@@ -6,7 +6,7 @@ from pyscreenshot.util import platform_is_osx
 
 PROGRAM = "screencapture"
 # https://ss64.com/osx/screencapture.html
-#  By default screneshots are saved as .png files,
+#  By default screenshots are saved as .png files,
 
 
 class ScreencaptureError(Exception):

--- a/tests/fillscreen.py
+++ b/tests/fillscreen.py
@@ -73,7 +73,7 @@ def init():
             raise FillscreenError("pqiv stopped: %s" % proc)
 
         # if the OS has color correction
-        #  then the screenshot has slighly different color than the original image
+        #  then the screenshot has slightly different color than the original image
         if platform_is_win() or platform_is_osx():
             refimgpath = refimgpath + ".pil.png"
             im = pyscreenshot.grab(backend="pil")


### PR DESCRIPTION
There are small typos in:
- README.md
- pyscreenshot/examples/virtdisp.py
- pyscreenshot/plugins/mac_screencapture.py
- tests/fillscreen.py

Fixes:
- Should read `displaying` rather than `diplaying`.
- Should read `slightly` rather than `slighly`.
- Should read `screenshots` rather than `screneshots`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md