### PR TITLE
Simple implementation of freedesktop portal

### DIFF
--- a/doc/hierarchy.dot
+++ b/doc/hierarchy.dot
@@ -32,6 +32,7 @@ digraph G {
             pyscreenshot -> ScreencaptureWrapper
             pyscreenshot -> Gdk3PixbufWrapper
             pyscreenshot -> GnomeScreenshotWrapper
+            pyscreenshot -> FreedesktopDBusWrapper
             pyscreenshot -> GnomeDBusWrapper
             pyscreenshot -> KwinDBusWrapper
             pyscreenshot -> MssWrapper
@@ -71,7 +72,7 @@ digraph G {
     Qt5GrabWindowWrapper -> PyQt5 -> Qt5;
     PySideGrabWindowWrapper -> PySide -> Qt4;
     PySide2GrabWindowWrapper -> PySide2 -> Qt5;
-    
+
     Qt4 -> macOS;
     Qt4 -> Windows;
     Qt4 -> X11;

--- a/pyscreenshot/loader.py
+++ b/pyscreenshot/loader.py
@@ -4,6 +4,7 @@ import traceback
 from pyscreenshot.childproc import childprocess_grab
 from pyscreenshot.err import FailedBackendError
 from pyscreenshot.plugins.gdk3pixbuf import Gdk3PixbufWrapper
+from pyscreenshot.plugins.freedesktop_dbus import FreedesktopDBusWrapper
 from pyscreenshot.plugins.gnome_dbus import GnomeDBusWrapper
 from pyscreenshot.plugins.gnome_screenshot import GnomeScreenshotWrapper
 from pyscreenshot.plugins.grim import GrimWrapper
@@ -45,6 +46,7 @@ backend_dict = {
     Gdk3PixbufWrapper.name: Gdk3PixbufWrapper,
     ScreencaptureWrapper.name: ScreencaptureWrapper,
     MacQuartzWrapper.name: MacQuartzWrapper,
+    FreedesktopDBusWrapper.name: FreedesktopDBusWrapper,
     GnomeDBusWrapper.name: GnomeDBusWrapper,
     GnomeScreenshotWrapper.name: GnomeScreenshotWrapper,
     KwinDBusWrapper.name: KwinDBusWrapper,
@@ -77,6 +79,8 @@ def backends(childprocess):
             yield WxScreen
             for x in qt():
                 yield x
+        yield FreedesktopDBusWrapper
+
         yield GnomeDBusWrapper
 
         # on screen notification

--- a/pyscreenshot/plugins/freedesktop_dbus.py
+++ b/pyscreenshot/plugins/freedesktop_dbus.py
@@ -1,0 +1,60 @@
+import dbus
+from dbus.mainloop.glib import DBusGMainLoop
+from gi.repository import GLib
+from PIL import Image
+import os
+import shutil
+import tempfile
+
+from pyscreenshot.plugins.backend import UNKNOWN_VERSION, CBackend
+
+
+DBusGMainLoop(set_as_default=True)
+loop = GLib.MainLoop()
+bus = dbus.SessionBus()
+
+# A better reference could be to implement this:
+# https://gist.github.com/danshick/3446dac24c64ce6172eced4ac255ac3d
+# This file has a very simple implementation.
+# It uses org.freedesktop.portal.Screenshot DBus interface,
+# so it asks for user permission to share the screenshot
+
+
+class FreedesktopDBusWrapper(CBackend):
+    """Plugin for ``pyscreenshot`` that uses Freedesktop's
+    org.freedesktop.portal.Screenshot DBus interface
+
+    This plugin can take screenshot when system is running Wayland.
+    """
+
+    name = "freedesktop-portal"
+    is_subprocess = True
+
+    def backend_version(self):
+        return UNKNOWN_VERSION
+
+    def grab(self, bbox=None):
+        tempdir = tempfile.TemporaryDirectory()
+        img_tmp_path = os.path.join(tempdir.name, 'screenshot.png')
+
+        im = False
+
+        def handler(*args, **kwargs):
+            if args[0] == 0:
+                shutil.move(str(args[1]['uri']).split('file://', 1)[-1], img_tmp_path)
+            loop.quit()
+
+        bus.add_signal_receiver(handler, signal_name='Response', dbus_interface='org.freedesktop.portal.Request')
+        proxy = bus.get_object('org.freedesktop.portal.Desktop', '/org/freedesktop/portal/desktop')
+        screenshot_iface = dbus.Interface(proxy, dbus_interface='org.freedesktop.portal.Screenshot')
+        screenshot_iface.Screenshot('', {'interactive': False})
+
+        loop.run()
+
+        if os.path.isfile(img_tmp_path):
+            im = Image.open(img_tmp_path)
+
+        if bbox and im:
+            im = im.crop(bbox)
+
+        return im

--- a/pyscreenshot/plugins/freedesktop_dbus.py
+++ b/pyscreenshot/plugins/freedesktop_dbus.py
@@ -1,60 +1,72 @@
-import dbus
-from dbus.mainloop.glib import DBusGMainLoop
-from gi.repository import GLib
-from PIL import Image
+import logging
 import os
-import shutil
-import tempfile
+from PIL import Image
 
 from pyscreenshot.plugins.backend import UNKNOWN_VERSION, CBackend
 
+log = logging.getLogger(__name__)
 
-DBusGMainLoop(set_as_default=True)
-loop = GLib.MainLoop()
-bus = dbus.SessionBus()
 
-# A better reference could be to implement this:
-# https://gist.github.com/danshick/3446dac24c64ce6172eced4ac255ac3d
-# This file has a very simple implementation.
-# It uses org.freedesktop.portal.Screenshot DBus interface,
-# so it asks for user permission to share the screenshot
+class FreedesktopDBusError(Exception):
+    pass
 
 
 class FreedesktopDBusWrapper(CBackend):
-    """Plugin for ``pyscreenshot`` that uses Freedesktop's
-    org.freedesktop.portal.Screenshot DBus interface
-
-    This plugin can take screenshot when system is running Wayland.
-    """
-
-    name = "freedesktop-portal"
+    name = "freedesktop_dbus"
     is_subprocess = True
 
-    def backend_version(self):
-        return UNKNOWN_VERSION
-
     def grab(self, bbox=None):
-        tempdir = tempfile.TemporaryDirectory()
-        img_tmp_path = os.path.join(tempdir.name, 'screenshot.png')
+        has_jeepney = False
+        try:
+            from jeepney import DBusAddress, new_method_call
+            from jeepney.bus_messages import message_bus, MatchRule
+            from jeepney.io.blocking import open_dbus_connection, Proxy
+
+            has_jeepney = True
+        except ImportError:
+            pass
+
+        if not has_jeepney:
+            raise FreedesktopDBusError("jeepney library is missing")
+
+        portal = DBusAddress(
+            object_path='/org/freedesktop/portal/desktop',
+            bus_name='org.freedesktop.portal.Desktop',
+        )
+        screenshot = portal.with_interface('org.freedesktop.portal.Screenshot')
+
+        conn = open_dbus_connection()
+
+        token = 'pyscreenshot'
+        sender_name = conn.unique_name[1:].replace('.', '_')
+        handle = f"/org/freedesktop/portal/desktop/request/{sender_name}/{token}"
+
+        response_rule = MatchRule(
+            type='signal', interface='org.freedesktop.portal.Request', path=handle
+        )
+        Proxy(message_bus, conn).AddMatch(response_rule)
+
+        with conn.filter(response_rule) as responses:
+            req = new_method_call(screenshot, 'Screenshot', 'sa{sv}', (
+                '', {'handle_token': ('s', token), 'interactive': ('b', False)}
+            ))
+            conn.send_and_get_reply(req)
+            response_msg = conn.recv_until_filtered(responses)
+
+        response, results = response_msg.body
 
         im = False
+        if response == 0:
+            filename = results['uri'][1].split('file://', 1)[-1]
+            if os.path.isfile(filename):
+                im = Image.open(filename)
+                os.remove(filename)
 
-        def handler(*args, **kwargs):
-            if args[0] == 0:
-                shutil.move(str(args[1]['uri']).split('file://', 1)[-1], img_tmp_path)
-            loop.quit()
-
-        bus.add_signal_receiver(handler, signal_name='Response', dbus_interface='org.freedesktop.portal.Request')
-        proxy = bus.get_object('org.freedesktop.portal.Desktop', '/org/freedesktop/portal/desktop')
-        screenshot_iface = dbus.Interface(proxy, dbus_interface='org.freedesktop.portal.Screenshot')
-        screenshot_iface.Screenshot('', {'interactive': False})
-
-        loop.run()
-
-        if os.path.isfile(img_tmp_path):
-            im = Image.open(img_tmp_path)
+        conn.close()
 
         if bbox and im:
             im = im.crop(bbox)
-
         return im
+
+    def backend_version(self):
+        return UNKNOWN_VERSION


### PR DESCRIPTION
It seems that starting with GNOME 42, we are not able to use the usual `gnome-screenshot` tool, and also the `gnome-dbus` plugin seems to not work. This plugin would use the Freedesktop portal to get the screenshot. Related to #91 .